### PR TITLE
Add support for overrides

### DIFF
--- a/.changeset/itchy-maps-cover.md
+++ b/.changeset/itchy-maps-cover.md
@@ -1,0 +1,5 @@
+---
+"@stackla/widget-utils": patch
+---
+
+Add css variable overrides & defaults

--- a/package.json
+++ b/package.json
@@ -12,36 +12,44 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
     },
     "./types": "./dist/types/index.d.ts",
     "./libs": {
       "import": "./dist/libs/index.js",
-      "types": "./dist/libs/index.d.ts"
+      "types": "./dist/libs/index.d.ts",
+      "require": "./dist/libs/index.js"
     },
     "./components": {
       "import": "./dist/libs/components/index.js",
-      "types": "./dist/libs/components/index.d.ts"
+      "types": "./dist/libs/components/index.d.ts",
+      "require": "./dist/libs/components/index.js"
     },
     "./extensions": {
       "import": "./dist/libs/extensions/index.js",
-      "types": "./dist/libs/extensions/index.d.ts"
+      "types": "./dist/libs/extensions/index.d.ts",
+      "require": "./dist/libs/extensions/index.js"
     },
     "./extensions/swiper": {
       "import": "./dist/libs/extensions/swiper/index.js",
-      "types": "./dist/libs/extensions/swiper/index.d.ts"
+      "types": "./dist/libs/extensions/swiper/index.d.ts",
+      "require": "./dist/libs/extensions/swiper/index.js"
     },
     "./extensions/masonry": {
       "import": "./dist/libs/extensions/masonry/index.js",
-      "types": "./dist/libs/extensions/masonry/index.d.ts"
+      "types": "./dist/libs/extensions/masonry/index.d.ts",
+      "require": "./dist/libs/extensions/masonry/index.js"
     },
     "./templates": {
       "import": "./dist/libs/templates/index.js",
-      "types": "./dist/libs/templates/index.d.ts"
+      "types": "./dist/libs/templates/index.d.ts",
+      "require": "./dist/libs/templates/index.js"
     },
     "./hooks": {
       "import": "./dist/hooks/index.js",
-      "types": "./dist/hooks/index.d.ts"
+      "types": "./dist/hooks/index.d.ts",
+      "require": "./dist/hooks/index.js"
     }
   },
   "scripts": {

--- a/src/libs/css-variables.ts
+++ b/src/libs/css-variables.ts
@@ -1,4 +1,4 @@
-import type { ISdk, Style } from "../"
+import type { ISdk, Style, StyleVariables } from "../"
 
 declare const sdk: ISdk
 
@@ -26,9 +26,10 @@ export function trimHashValuesFromObject(obj: Style): Record<string, string> {
   }, {})
 }
 
-export default function getCSSVariables(): string {
+export default function getCSSVariables(defaults: StyleVariables, overrides: StyleVariables): string {
   const styles = sdk.getStyleConfig()
   const inlineTileSettings = sdk.getInlineTileConfig()
+
   const {
     widget_background,
     text_tile_background,
@@ -50,19 +51,19 @@ export default function getCSSVariables(): string {
   const { show_timestamp, show_caption } = inlineTileSettings
 
   const cssVariables: { [key: string]: string } = {
-    "--widget-background": `#${widget_background}`,
-    "--text-tile-background": `#${text_tile_background}`,
-    "--text-tile-font-color": `#${text_tile_font_color}`,
-    "--text-tile-link-color": `#${text_tile_link_color}`,
-    "--text-tile-user-name-font-color": `#${text_tile_user_name_font_color}`,
-    "--text-tile-user-handle-font-color": `#${text_tile_user_handle_font_color}`,
-    "--text-tile-tag-font-color": `#${text_tile_font_color}`,
-    "--shopspot-btn-background": `#${shopspot_btn_background}`,
-    "--shopspot-btn-font-color": `#${shopspot_btn_font_color}`,
-    "--margin": `${margin ? margin : 0}px`,
-    "--text-tile-font-size": `${text_tile_font_size}px`,
-    "--text-tile-user-name-font-size": `${text_tile_user_name_font_size}px`,
-    "--text-tile-user-handle-font-size": `${text_tile_user_handle_font_size ? text_tile_user_handle_font_size : 12}px`,
+    "--widget-background": `#${overrides.widget_background ?? widget_background ?? defaults.widget_background}`,
+    "--text-tile-background": `#${overrides.text_tile_background ?? text_tile_background ?? defaults.text_tile_background}`,
+    "--text-tile-font-color": `#${overrides.text_tile_font_color ?? text_tile_font_color ?? defaults.text_tile_font_color}`,
+    "--text-tile-link-color": `#${overrides.text_tile_link_color ?? text_tile_link_color ?? defaults.text_tile_link_color}`,
+    "--text-tile-user-name-font-color": `#${overrides.text_tile_user_name_font_color ?? text_tile_user_name_font_color ?? defaults.text_tile_user_name_font_color}`,
+    "--text-tile-user-handle-font-color": `#${overrides.text_tile_user_handle_font_color ?? text_tile_user_handle_font_color ?? defaults.text_tile_user_handle_font_color}`,
+    "--text-tile-tag-font-color": `#${overrides.text_tile_font_color ?? text_tile_font_color ?? defaults.text_tile_font_color}`,
+    "--shopspot-btn-background": `#${overrides.shopspot_btn_background ?? shopspot_btn_background ?? defaults.shopspot_btn_background}`,
+    "--shopspot-btn-font-color": `#${overrides.shopspot_btn_font_color ?? shopspot_btn_font_color ?? defaults.shopspot_btn_font_color}`,
+    "--margin": `${overrides.margin ?? margin ?? 0}px`,
+    "--text-tile-font-size": `${overrides.text_tile_font_size ?? text_tile_font_size ?? defaults.text_tile_font_size}px`,
+    "--text-tile-user-name-font-size": `${overrides.text_tile_user_name_font_size ?? text_tile_user_name_font_size ?? defaults.text_tile_user_name_font_size}px`,
+    "--text-tile-user-handle-font-size": `${overrides.text_tile_user_handle_font_size ?? text_tile_user_handle_font_size ?? defaults.text_tile_user_handle_font_size}px`,
     "--show-caption": `${show_caption ? "block" : "none"}`,
     "--tile-timephrase-display": `${show_timestamp ? "inline-block" : "none"}`,
     "--shopspot-icon": shopspot_icon
@@ -72,9 +73,9 @@ export default function getCSSVariables(): string {
     "--cta-button-background-color": `#000000`,
     "--cta-button-font-color": `#ffffff`,
     "--cta-button-font-size": `18px`,
-    "--expanded-tile-border-radius": `${expanded_tile_border_radius}px`,
+    "--expanded-tile-border-radius": `${overrides.expanded_tile_border_radius ?? expanded_tile_border_radius ?? defaults.expanded_tile_border_radius}px`,
     "--tile-size": getTileSizeByWidget(),
-    "--tile-tag-background": `#${tile_tag_background}`
+    "--tile-tag-background": `#${overrides.tile_tag_background ?? tile_tag_background ?? defaults.tile_tag_background}`
   }
 
   return Object.entries(cssVariables)

--- a/src/widget-loader.ts
+++ b/src/widget-loader.ts
@@ -21,7 +21,7 @@ import {
 } from "./libs"
 import { onExpandedTileCrossSellersRendered } from "./libs/components/expanded-tile-swiper/product-recs-swiper.loader"
 import getCSSVariables from "./libs/css-variables"
-import { ISdk, Template } from "./types"
+import { ISdk, Style, Template } from "./types"
 import {
   handleTileImageError,
   handleAllTileImageRendered,
@@ -73,11 +73,19 @@ interface CustomTemplate {
 
 type Templates = Record<string, Partial<CustomTemplate>>
 
+export type StyleVariables = Record<keyof Style, string | number>
+
 export interface MyWidgetSettings {
   features: Partial<Features>
   callbacks: Partial<Callbacks>
   extensions: Partial<Extensions>
   templates: Partial<Templates>
+  styles: {
+    variables?: {
+      defaults?: Partial<StyleVariables>
+      overrides?: Partial<StyleVariables>
+    }
+  }
 }
 
 export interface EnforcedWidgetSettings {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
Allow CSS settings to be overridden when a base style is preferred over usage of a variable.
I.e. Nightfall requires a black ui, and white font. While 90% of widgets utilise a similar style. Its important to support overrides when a developer does not want to use existing widget settings coming from express.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 