### PR TITLE
Adding new css variable for unitless tile-size

### DIFF
--- a/.changeset/olive-wolves-join.md
+++ b/.changeset/olive-wolves-join.md
@@ -1,0 +1,5 @@
+---
+"@stackla/widget-utils": patch
+---
+
+adding new css variable for unitless tile-size

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "eslint src/.",
     "typecheck": "npx tsc",
     "test": "jest",
+    "test-updatesnapshot": "jest --updateSnapshot",
     "build:types": "npm run build:types:cjs && npm run build:types:esm",
     "build:types:cjs": "tsc --project tsconfig.json",
     "build:types:esm": "tsc --project tsconfig.esm.json",

--- a/src/libs/__snapshots__/css-variables.spec.ts.snap
+++ b/src/libs/__snapshots__/css-variables.spec.ts.snap
@@ -23,5 +23,6 @@ exports[`Widget Functions getCSSVariables should return the correct CSS variable
 --cta-button-font-size: 18px;
 --expanded-tile-border-radius: 5px;
 --tile-size: 265.5px;
+--tile-size-unitless: 265.5;
 --tile-tag-background: #D6D4D5;"
 `;

--- a/src/libs/css-variables.spec.ts
+++ b/src/libs/css-variables.spec.ts
@@ -16,18 +16,18 @@ describe("Widget Functions", () => {
       sdk.getStyleConfig.mockReturnValue({})
 
       const result = getTileSizeByWidget()
-      expect(result).toBe("265.5px")
+      expect(result).toEqual({ "--tile-size": "265.5px", "--tile-size-unitless": "265.5" })
     })
 
     it("should return correct tile size based on inline_tile_size", () => {
       sdk.getStyleConfig.mockReturnValue({ inline_tile_size: "small" })
-      expect(getTileSizeByWidget()).toBe("173px")
+      expect(getTileSizeByWidget()).toEqual({ "--tile-size": "173px", "--tile-size-unitless": "173" })
 
       sdk.getStyleConfig.mockReturnValue({ inline_tile_size: "medium" })
-      expect(getTileSizeByWidget()).toBe("265.5px")
+      expect(getTileSizeByWidget()).toEqual({ "--tile-size": "265.5px", "--tile-size-unitless": "265.5" })
 
       sdk.getStyleConfig.mockReturnValue({ inline_tile_size: "large" })
-      expect(getTileSizeByWidget()).toBe("400px")
+      expect(getTileSizeByWidget()).toEqual({ "--tile-size": "400px", "--tile-size-unitless": "400" })
     })
   })
   // Tests for getCSSVariables

--- a/src/libs/css-variables.ts
+++ b/src/libs/css-variables.ts
@@ -2,7 +2,7 @@ import type { ISdk, Style } from "../"
 
 declare const sdk: ISdk
 
-export function getTileSizeByWidget(): string {
+function getTileSize() {
   const style = sdk.getStyleConfig()
   const { inline_tile_size } = style
 
@@ -19,7 +19,13 @@ export function getTileSizeByWidget(): string {
   return tileSizes[inline_tile_size]
 }
 
-export function trimHashValuesFromObject(obj: Style): Record<string, string> {
+export function getTileSizeByWidget() {
+  const sizeWithUnit = getTileSize()
+  const sizeUnitless = sizeWithUnit.replace("px", "")
+  return { "--tile-size": sizeWithUnit, "--tile-size-unitless": sizeUnitless }
+}
+
+export function trimHashValuesFromObject(obj: Style) {
   return Object.entries(obj).reduce((acc: Record<string, string>, [key, value]) => {
     acc[key] = typeof value === "string" && value.startsWith("#") ? value.replace("#", "") : value
     return acc
@@ -73,7 +79,7 @@ export default function getCSSVariables(): string {
     "--cta-button-font-color": `#ffffff`,
     "--cta-button-font-size": `18px`,
     "--expanded-tile-border-radius": `${expanded_tile_border_radius}px`,
-    "--tile-size": getTileSizeByWidget(),
+    ...getTileSizeByWidget(),
     "--tile-tag-background": `#${tile_tag_background}`
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
<!--- Describe your changes -->
A new unitless tile-size css variable. This can be used for doing responsive size calculation operations

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 