### PR TITLE
Disable autoplay for youtube videos

### DIFF
--- a/.changeset/rude-snakes-camp.md
+++ b/.changeset/rude-snakes-camp.md
@@ -1,0 +1,5 @@
+---
+"@stackla/widget-utils": patch
+---
+
+Autoplay should be switched off by default, videos should only play when a tile is reached (needs future commit)

--- a/src/libs/components/expanded-tile-swiper/tile.template.tsx
+++ b/src/libs/components/expanded-tile-swiper/tile.template.tsx
@@ -246,7 +246,7 @@ function RenderFacebookFallbackTemplate({ tile }: { tile: Tile }) {
 
 function RenderYoutubeTemplate({ tile }: { tile: Tile }) {
   const youtubeId = tile.youtube_id as string
-  const src = `https://www.youtube.com/embed/${youtubeId}?autoplay=1&mute=1`
+  const src = `https://www.youtube.com/embed/${youtubeId}?mute=1`
   const title = tile.title as string
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
<!--- Describe your changes -->
Videos are autoplaying without being on the active tile. We should instead trigger a lot when we reach that given tile. We can use video.play and video.pause

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 