### PR TITLE
UGC-18831: Control video playback on load into view and pause otherwise

### DIFF
--- a/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
+++ b/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
@@ -36,12 +36,8 @@ function initializeSwiperForExpandedTiles(initialTileId: string) {
           const tileIndex = initialTileId ? getSwiperIndexforTile(widgetSelector, initialTileId) : 0
           swiper.slideToLoop(tileIndex, 0, false)
         },
-        navigationNext: (swiper: Swiper) => {
-          controlVideoPlayback(swiper)
-        },
-        navigationPrev: (swiper: Swiper) => {
-          controlVideoPlayback(swiper)
-        }
+        navigationNext: controlVideoPlayback,
+        navigationPrev: controlVideoPlayback
       }
     }
   })
@@ -53,6 +49,7 @@ function controlVideoPlayback(swiper: Swiper) {
 
   activeElement?.play()
   previousElement?.pause()
+  previousElement && (previousElement.currentTime = 0)
 }
 
 function getSwiperVideoElement(swiper: Swiper, index: number) {

--- a/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
+++ b/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
@@ -48,8 +48,11 @@ function controlVideoPlayback(swiper: Swiper) {
   const previousElement = getSwiperVideoElement(swiper, swiper.previousIndex)
 
   activeElement?.play()
-  previousElement?.pause()
-  previousElement && (previousElement.currentTime = 0)
+
+  if (previousElement) {
+    previousElement?.pause()
+    previousElement.currentTime = 0
+  }
 }
 
 function getSwiperVideoElement(swiper: Swiper, index: number) {

--- a/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
+++ b/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
@@ -35,10 +35,29 @@ function initializeSwiperForExpandedTiles(initialTileId: string) {
         beforeInit: (swiper: Swiper) => {
           const tileIndex = initialTileId ? getSwiperIndexforTile(widgetSelector, initialTileId) : 0
           swiper.slideToLoop(tileIndex, 0, false)
+        },
+        navigationNext: (swiper: Swiper) => {
+          controlVideoPlayback(swiper)
+        },
+        navigationPrev: (swiper: Swiper) => {
+          controlVideoPlayback(swiper)
         }
       }
     }
   })
+}
+
+function controlVideoPlayback(swiper: Swiper) {
+  const activeElement = getSwiperVideoElement(swiper, swiper.realIndex)
+  const previousElement = getSwiperVideoElement(swiper, swiper.previousIndex)
+
+  activeElement?.play()
+  previousElement?.pause()
+}
+
+function getSwiperVideoElement(swiper: Swiper, index: number) {
+  const element = swiper.slides[index]
+  return element.querySelector<HTMLVideoElement>(".panel .panel-left .video-content-wrapper video")
 }
 
 export function onTileExpand(tileId: string) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
<!--- Describe your changes -->
Control video playback on tile load. Play video only when the tile is rendered in view and pause otherwise.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

https://nostosolutions.atlassian.net/browse/UGC-18831

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 