### PR TITLE
UGC-18331: Tiktok auto play handling on render

### DIFF
--- a/src/libs/components/expanded-tile-swiper/base.template.tsx
+++ b/src/libs/components/expanded-tile-swiper/base.template.tsx
@@ -17,7 +17,11 @@ export function ExpandedTiles(sdk: ISdk) {
       <div class="swiper swiper-expanded">
         <div class="swiper-wrapper ugc-tiles">
           {Object.values(tiles).map(tile => (
-            <div class="ugc-tile swiper-slide" data-id={tile.id} data-yt-id={tile.youtube_id || ""}>
+            <div
+              class="ugc-tile swiper-slide"
+              data-id={tile.id}
+              data-yt-id={tile.youtube_id || ""}
+              data-tiktok-id={tile.tiktok_id || ""}>
               <ExpandedTile sdk={sdk} tile={tile} />
             </div>
           ))}

--- a/src/libs/components/expanded-tile-swiper/tiktok-message.ts
+++ b/src/libs/components/expanded-tile-swiper/tiktok-message.ts
@@ -1,0 +1,16 @@
+type TiktokMessageType = "play" | "pause" | "mute" | "unMute" | "seekTo"
+
+export function playTiktokVideo(frameWindow: Window) {
+  postTiktokMessage(frameWindow, "unMute")
+  postTiktokMessage(frameWindow, "play")
+}
+
+export function pauseTiktokVideo(frameWindow: Window) {
+  postTiktokMessage(frameWindow, "mute")
+  postTiktokMessage(frameWindow, "pause")
+  postTiktokMessage(frameWindow, "seekTo", 0)
+}
+
+export function postTiktokMessage(frameWindow: Window, type: TiktokMessageType, value?: number) {
+  frameWindow.postMessage({ type, value, "x-tiktok-player": true }, "https://www.tiktok.com")
+}

--- a/src/libs/components/expanded-tile-swiper/tiktok-message.ts
+++ b/src/libs/components/expanded-tile-swiper/tiktok-message.ts
@@ -1,16 +1,32 @@
 type TiktokMessageType = "play" | "pause" | "mute" | "unMute" | "seekTo"
 
+/**
+ * Post tiktok messages to play a video/audio
+ *
+ * @param { Window } frameWindow - tiktok frame contentWindow
+ */
 export function playTiktokVideo(frameWindow: Window) {
   postTiktokMessage(frameWindow, "unMute")
   postTiktokMessage(frameWindow, "play")
 }
 
+/**
+ * Post tiktok messages to pause a video/audio and reset the current video progress
+ *
+ * @param { Window } frameWindow - tiktok frame contentWindow
+ */
 export function pauseTiktokVideo(frameWindow: Window) {
   postTiktokMessage(frameWindow, "mute")
   postTiktokMessage(frameWindow, "pause")
   postTiktokMessage(frameWindow, "seekTo", 0)
 }
 
+/**
+ *
+ * @param { Window } frameWindow - tiktok frame contentWindow
+ * @param { TiktokMessageType } type - message type to be posted ("play" | "pause" | "mute" | "unMute" | "seekTo")
+ * @param { number } value - position of media progress. 0 to reset progress
+ */
 export function postTiktokMessage(frameWindow: Window, type: TiktokMessageType, value?: number) {
   frameWindow.postMessage({ type, value, "x-tiktok-player": true }, "https://www.tiktok.com")
 }

--- a/src/libs/components/expanded-tile-swiper/tile.template.tsx
+++ b/src/libs/components/expanded-tile-swiper/tile.template.tsx
@@ -208,15 +208,18 @@ function RenderTwitterTemplate({ tile }: { tile: Tile }) {
 }
 
 function RenderTikTokTemplate({ tile }: { tile: Tile }) {
-  const tiktokId = tile.original_url.split("/")[5]
+  // extracts
+  const tiktokId = tile.tiktok_id
 
   return (
     <iframe
+      id={`tiktok-frame-${tile.id}-${tiktokId}`}
       loading="lazy"
       class="video-content"
       frameborder="0"
       allowfullscreen
-      src={`https://www.tiktok.com/player/v1/${tiktokId}`}
+      allow="autoplay" // refer https://developer.chrome.com/blog/autoplay/
+      src={`https://www.tiktok.com/player/v1/${tiktokId}?rel=0`}
     />
   )
 }

--- a/src/libs/extensions/swiper/swiper.extension.ts
+++ b/src/libs/extensions/swiper/swiper.extension.ts
@@ -4,6 +4,11 @@ import { Keyboard, Manipulation, Mousewheel, Navigation } from "swiper/modules"
 
 declare const sdk: SdkSwiper
 
+export type LookupAttr = {
+  name: string
+  value: string
+}
+
 export function initializeSwiper({
   id,
   widgetSelector,
@@ -65,9 +70,17 @@ export function refreshSwiper(id: string) {
   }
 }
 
-export function getSwiperIndexforTile(swiperSelector: HTMLElement, tileId: string) {
+export function getSwiperIndexforTile(swiperSelector: HTMLElement, tileId: string, lookupAttr?: LookupAttr) {
   const slideElements = swiperSelector.querySelectorAll<HTMLElement>(".swiper-slide")
-  const index = Array.from(slideElements).findIndex(element => element.getAttribute("data-id") === tileId)
+  const index = (() => {
+    if (lookupAttr) {
+      return Array.from(slideElements).findIndex(
+        element =>
+          element.getAttribute("data-id") === tileId && element.getAttribute(lookupAttr.name) === lookupAttr.value
+      )
+    }
+    return Array.from(slideElements).findIndex(element => element.getAttribute("data-id") === tileId)
+  })()
   return index < 0 ? 0 : index
 }
 
@@ -103,4 +116,8 @@ export function getInstance(id: string) {
 
 export function getActiveSlide(id: string) {
   return sdk[id]?.instance?.realIndex
+}
+
+export function getActiveSlideElement(id: string) {
+  return sdk[id]?.instance?.slides[getActiveSlide(id) || 0]
 }

--- a/src/libs/extensions/swiper/swiper.extension.ts
+++ b/src/libs/extensions/swiper/swiper.extension.ts
@@ -115,7 +115,7 @@ export function getInstance(id: string) {
 }
 
 export function getActiveSlide(id: string) {
-  return sdk[id]?.instance?.realIndex
+  return sdk[id]?.instance?.realIndex || 0
 }
 
 export function getActiveSlideElement(id: string) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
<!--- Describe your changes -->
Tiktok videos should be play automatically upon opening from inline tile. Videos should be paused while navigating away from the tile and re-played when while navigating to the tile

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->
https://nostosolutions.atlassian.net/browse/UGC-18831

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 