### PR TITLE
UGC-18817: Rename inner tile-image to tile-image-wrapper

### DIFF
--- a/src/libs/extensions/swiper/loader.extension.ts
+++ b/src/libs/extensions/swiper/loader.extension.ts
@@ -8,7 +8,7 @@ function enableTileContent(slide: HTMLElement) {
 }
 
 function enableTileImage(slide: HTMLElement) {
-  const tileImage = slide.querySelector<HTMLImageElement>(".tile-image > img")
+  const tileImage = slide.querySelector<HTMLImageElement>(".tile-image-wrapper > img")
   if (tileImage) {
     if (tileImage.complete) {
       enableTileContent(slide)

--- a/src/libs/extensions/swiper/overrides.scss
+++ b/src/libs/extensions/swiper/overrides.scss
@@ -31,7 +31,7 @@
       @extend %loading;
     }
 
-    .tile-image {
+    .tile-image-wrapper {
       height: 100%;
 
       > img {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
<!--- Describe your changes -->
The `.tile-image` class name is used to represent swiper slide and all as a wrapper for image. So, we name the image wrapper to `.tile-image-wrapper` in order to distinguish between the two.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 