### PR TITLE
Remove tiles per page

### DIFF
--- a/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
+++ b/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
@@ -31,8 +31,6 @@ function initializeSwiperForExpandedTiles(initialTileId: string) {
     throw new Error("Failed to find widget UI element. Failed to initialise Glide")
   }
 
-  sdk.tiles.setVisibleTilesCount(2)
-
   initializeSwiper({
     id: "expanded",
     widgetSelector,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
<!--- Describe your changes -->
Tiles per page is used to dictate how many tiles are loaded at a time, there is no reason why this 2 should be placed here as it should only be used in the context of inline tiles.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 