### PR TITLE
fix: update Swiper import and initialization; remove redundant dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@stackla/widget-utils",
       "version": "0.1.34",
       "license": "ISC",
-      "dependencies": {
-        "swiper": "^11.1.14"
-      },
       "devDependencies": {
         "@babel/preset-env": "^7.26.0",
         "@changesets/cli": "^2.27.9",

--- a/package.json
+++ b/package.json
@@ -112,12 +112,10 @@
     "stylelint-prettier": "^5.0.2",
     "stylelint-scss": "^6.8.1",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "swiper": "^11.1.14"
   },
   "files": [
     "dist"
-  ],
-  "dependencies": {
-    "swiper": "^11.1.14"
-  }
+  ]
 }

--- a/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
+++ b/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
@@ -9,7 +9,7 @@ import {
   updateSwiperInstance
 } from "../../extensions/swiper/swiper.extension"
 import { waitForElm } from "../../widget.features"
-import Swiper from "swiper"
+import { type Swiper } from "swiper"
 import { pauseTiktokVideo, playTiktokVideo } from "./tiktok-message"
 import { ISdk, SwiperData } from "../../../types"
 import { EVENT_LOAD_MORE } from "../../../events"

--- a/src/libs/extensions/swiper/index.ts
+++ b/src/libs/extensions/swiper/index.ts
@@ -3,6 +3,5 @@ export {
   isSwiperLoading,
   updateSwiperInstance,
   setSwiperLoadingStatus,
-  refreshSwiper,
-  Swiper
+  refreshSwiper
 } from "./swiper.extension"

--- a/src/libs/extensions/swiper/swiper.extension.ts
+++ b/src/libs/extensions/swiper/swiper.extension.ts
@@ -1,5 +1,4 @@
 import { SdkSwiper, SwiperData, SwiperProps } from "../../../types/SdkSwiper"
-import Swiper from "swiper"
 import { Autoplay, EffectCoverflow, Keyboard, Manipulation, Mousewheel, Navigation } from "swiper/modules"
 
 const swiperContainer: SdkSwiper = {}
@@ -30,7 +29,10 @@ export function initializeSwiper({ id, widgetSelector, prevButton, nextButton, p
     swiperContainer[id] = { pageIndex: 1 }
   }
 
-  swiperContainer[id]!.instance = new Swiper(widgetSelector, {
+  console.log(window.ugc)
+
+  // @ts-expect-error Swiper is a global variable, TODO add to shims
+  swiperContainer[id]!.instance = new window.ugc.libs.Swiper(widgetSelector, {
     modules: [Navigation, Manipulation, Keyboard, Mousewheel, Autoplay, EffectCoverflow],
     spaceBetween: 10,
     observer: true,
@@ -129,5 +131,3 @@ export function updateSwiperInstance(id: string, updateProps: (swiperData: Swipe
     updateProps(swiperContainer[id])
   }
 }
-
-export { Swiper }

--- a/src/libs/extensions/swiper/swiper.extension.ts
+++ b/src/libs/extensions/swiper/swiper.extension.ts
@@ -29,9 +29,6 @@ export function initializeSwiper({ id, widgetSelector, prevButton, nextButton, p
     swiperContainer[id] = { pageIndex: 1 }
   }
 
-  console.log(window.ugc)
-
-  // @ts-expect-error Swiper is a global variable, TODO add to shims
   swiperContainer[id]!.instance = new window.ugc.libs.Swiper(widgetSelector, {
     modules: [Navigation, Manipulation, Keyboard, Mousewheel, Autoplay, EffectCoverflow],
     spaceBetween: 10,

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -1,6 +1,11 @@
 interface Window {
   scrollLocked: boolean,
-  __isLoading: boolean
+  __isLoading: boolean,
+  ugc: {
+    libs: {
+      Swiper: typeof import("swiper").Swiper
+    }
+  }
 }
 
 declare module "*.scss" {

--- a/src/widget-loader.ts
+++ b/src/widget-loader.ts
@@ -15,7 +15,7 @@ import {
   renderMasonryLayout
 } from "./libs/extensions/masonry/masonry.extension"
 import { loadExpandedTileTemplates } from "./libs/components/expanded-tile-swiper"
-import { callbackDefaults, Callbacks, EVENT_LOAD, loadListeners } from "./events"
+import { callbackDefaults, Callbacks, loadListeners } from "./events"
 import IWidgetRequest from "./types/core/widget-request"
 
 declare const sdk: ISdk
@@ -317,16 +317,14 @@ function addConfigFilter<C>(settings: EnforcedWidgetSettings<C>) {
 }
 
 export function loadWidget<C>(settings?: MyWidgetSettings<C>) {
-  sdk.addEventListener(EVENT_LOAD, () => {
-    const settingsWithDefaults = mergeSettingsWithDefaults(settings)
-    addConfigStyles(settingsWithDefaults)
-    addConfigExpandedTileSettings(settingsWithDefaults)
-    addConfigInlineTileSettings(settingsWithDefaults)
-    addCSSVariablesToPlacement(getCSSVariables(settings?.features))
-    addConfigFilter(settingsWithDefaults)
-    loadTemplates(settingsWithDefaults)
-    loadFeatures(settingsWithDefaults)
-    loadExtensions(settingsWithDefaults)
-    loadListeners<C>(settingsWithDefaults)
-  })
+  const settingsWithDefaults = mergeSettingsWithDefaults(settings)
+  addConfigStyles(settingsWithDefaults)
+  addConfigExpandedTileSettings(settingsWithDefaults)
+  addConfigInlineTileSettings(settingsWithDefaults)
+  addCSSVariablesToPlacement(getCSSVariables(settings?.features))
+  addConfigFilter(settingsWithDefaults)
+  loadTemplates(settingsWithDefaults)
+  loadFeatures(settingsWithDefaults)
+  loadExtensions(settingsWithDefaults)
+  loadListeners<C>(settingsWithDefaults)
 }

--- a/src/widget-loader.ts
+++ b/src/widget-loader.ts
@@ -15,7 +15,7 @@ import {
   renderMasonryLayout
 } from "./libs/extensions/masonry/masonry.extension"
 import { loadExpandedTileTemplates } from "./libs/components/expanded-tile-swiper"
-import { callbackDefaults, Callbacks, loadListeners } from "./events"
+import { callbackDefaults, Callbacks, EVENT_LOAD, loadListeners } from "./events"
 import IWidgetRequest from "./types/core/widget-request"
 
 declare const sdk: ISdk
@@ -317,14 +317,16 @@ function addConfigFilter<C>(settings: EnforcedWidgetSettings<C>) {
 }
 
 export function loadWidget<C>(settings?: MyWidgetSettings<C>) {
-  const settingsWithDefaults = mergeSettingsWithDefaults(settings)
-  addConfigStyles(settingsWithDefaults)
-  addConfigExpandedTileSettings(settingsWithDefaults)
-  addConfigInlineTileSettings(settingsWithDefaults)
-  addCSSVariablesToPlacement(getCSSVariables(settings?.features))
-  addConfigFilter(settingsWithDefaults)
-  loadTemplates(settingsWithDefaults)
-  loadFeatures(settingsWithDefaults)
-  loadExtensions(settingsWithDefaults)
-  loadListeners<C>(settingsWithDefaults)
+  sdk.addEventListener(EVENT_LOAD, () => {
+    const settingsWithDefaults = mergeSettingsWithDefaults(settings)
+    addConfigStyles(settingsWithDefaults)
+    addConfigExpandedTileSettings(settingsWithDefaults)
+    addConfigInlineTileSettings(settingsWithDefaults)
+    addCSSVariablesToPlacement(getCSSVariables(settings?.features))
+    addConfigFilter(settingsWithDefaults)
+    loadTemplates(settingsWithDefaults)
+    loadFeatures(settingsWithDefaults)
+    loadExtensions(settingsWithDefaults)
+    loadListeners<C>(settingsWithDefaults)
+  })
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above prefixed with jira ticket number -->

## Description
Remove swiper from package, retrieve swiper from global libs from widget loader to reduce package size of slim packages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Related Jira ticket
<!--- Is there a Jira ticket for this change, if not - should there be? -->
<!--- If working on a new feature or change, please discuss it in an ticket first -->
<!--- If fixing a bug, there should be an ticket describing it with steps to reproduce -->
<!--- Please link to the ticket here: -->

## Testing
<!--- Step by step instructions on how to test it, including environment setup -->
<!--- Also please describe in detail how you tested your changes. -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation
<!--- Is the change documented or should it be?, link the relevant wiki/confluence page here. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

## Screenshots
<!--- If there is a visual element to the PR please share screenshots -->
<!--- Remember the saying "one picture says the same as a 1000 words". -->

 