### PR TITLE
feat: add event listener for tiles depleted in load more component

### DIFF
--- a/src/libs/components/load-more/load-more.component.ts
+++ b/src/libs/components/load-more/load-more.component.ts
@@ -1,5 +1,6 @@
 import { ISdk } from "src/types"
 import { LoadMoreTemplate as template } from "./load-more.template"
+import { EVENT_TILES_DEPLETED } from "src/events"
 
 declare const sdk: ISdk
 
@@ -11,6 +12,10 @@ export default class LoadMoreComponent extends HTMLElement {
   connectedCallback() {
     if (sdk.getStyleConfig().load_more_type === "button") {
       this.appendChild(template())
+
+      sdk.addEventListener(EVENT_TILES_DEPLETED, () => {
+        this.replaceChildren()
+      })
     }
   }
 

--- a/src/libs/components/load-more/load-more.component.ts
+++ b/src/libs/components/load-more/load-more.component.ts
@@ -1,6 +1,6 @@
 import { ISdk } from "src/types"
 import { LoadMoreTemplate as template } from "./load-more.template"
-import { EVENT_TILES_DEPLETED } from "src/events"
+import { EVENT_TILES_DEPLETED } from "../../../events"
 
 declare const sdk: ISdk
 


### PR DESCRIPTION
## Description

When tiles run out, we should hide load more

## Checklist
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

 