### PR TITLE
UGC-19258: pass tile id instead of tile object to Content Wrapper

### DIFF
--- a/.changeset/eleven-knives-know.md
+++ b/.changeset/eleven-knives-know.md
@@ -1,0 +1,5 @@
+---
+"@stackla/widget-utils": patch
+---
+
+pass tile id instead of tile object to Content Wrapper

--- a/src/libs/components/expanded-tile-swiper/tile.template.tsx
+++ b/src/libs/components/expanded-tile-swiper/tile.template.tsx
@@ -5,10 +5,16 @@ import { ExpandedTileProps, ShopspotProps, ContentWrapperProps } from "./types"
 
 declare const sdk: ISdk
 
-export function ContentWrapper({ tile, parent }: ContentWrapperProps) {
+export function ContentWrapper({ id, parent }: ContentWrapperProps) {
   const { show_shopspots } = sdk.getExpandedTileConfig()
+  const tile = sdk.getTileById(id)
 
-  const shopspotEnabled = sdk.isComponentLoaded("shopspots") && show_shopspots && !!tile.hotspots?.length
+  if (!tile) {
+    console.warn("Tile not found in ContentWrapper", id)
+    return <></>
+  }
+
+  const shopspotEnabled = sdk.isComponentLoaded("shopspots") && show_shopspots && !!tile?.hotspots?.length
 
   switch (tile.media) {
     case "video":
@@ -50,9 +56,9 @@ export function ExpandedTile({ tile }: ExpandedTileProps) {
           <div class="image-wrapper">
             <div class="image-wrapper-inner">
               {carouselGroupingEnabled ? (
-                <carousel-grouping parent={parent} tile={tile} tile-id={tile.id} mode="expanded" />
+                <carousel-grouping parent={parent} tile-id={tile.id} mode="expanded" />
               ) : (
-                <ContentWrapper tile={tile} parent={parent} />
+                <ContentWrapper id={tile.id} parent={parent} />
               )}
             </div>
           </div>

--- a/src/libs/components/expanded-tile-swiper/types.ts
+++ b/src/libs/components/expanded-tile-swiper/types.ts
@@ -11,6 +11,6 @@ export type ShopspotProps = {
 }
 
 export type ContentWrapperProps = {
-  tile: Tile
+  id: string
   parent?: string
 }


### PR DESCRIPTION
## Description

## Checklist
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

 