### PR TITLE
feat: export expanded tile template and remove loadExpandedTileSlider…

### DIFF
--- a/.changeset/sharp-melons-reflect.md
+++ b/.changeset/sharp-melons-reflect.md
@@ -1,0 +1,5 @@
+---
+"@stackla/widget-utils": patch
+---
+
+Export expanded tile template

--- a/src/libs/components/expanded-tile-swiper/index.ts
+++ b/src/libs/components/expanded-tile-swiper/index.ts
@@ -1,20 +1,4 @@
-import { ExpandedTiles } from "./base.template"
-import { ISdk } from "../../../"
-
-declare const sdk: ISdk
-
-function loadDefaultExpandedTileTemplates(addExpandedTileTemplates: boolean) {
-  if (!addExpandedTileTemplates) {
-    return
-  }
-
-  sdk.addTemplateToComponent(ExpandedTiles, "expanded-tiles")
-}
-
-export function loadExpandedTileTemplates(templateEnabled: boolean) {
-  loadDefaultExpandedTileTemplates(templateEnabled)
-}
-
+export * from "./base.template"
 export * from "./tile.template"
 export * from "./embed-youtube.template"
 export * from "./video.templates"

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -35,11 +35,6 @@ export interface Features {
    */
   hideBrokenImages: boolean
   /**
-   * @description Load the expanded tile slider
-   * @default true
-   */
-  loadExpandedTileSlider: boolean
-  /**
    * @description Load the tile content web component
    * @default true
    */

--- a/src/widget-loader.spec.tsx
+++ b/src/widget-loader.spec.tsx
@@ -1,6 +1,5 @@
 import { callbackDefaults } from "./events"
 import { injectFontFaces } from "./fonts"
-import { loadExpandedTileTemplates } from "./libs/components/expanded-tile-swiper"
 import { EnforcedWidgetSettings } from "./types"
 import { loadTemplates } from "./widget-loader"
 
@@ -15,10 +14,6 @@ const sdk = {
 // @ts-expect-error globals
 global.sdk = sdk
 
-jest.mock("./libs/components/expanded-tile-swiper", () => ({
-  loadExpandedTileTemplates: jest.fn()
-}))
-
 const settings: EnforcedWidgetSettings = {
   features: {
     showTitle: true,
@@ -27,7 +22,6 @@ const settings: EnforcedWidgetSettings = {
     addNewTilesAutomatically: true,
     handleLoadMore: true,
     hideBrokenImages: true,
-    loadExpandedTileSlider: true,
     loadTileContent: true,
     loadTimephrase: true
   },
@@ -52,26 +46,6 @@ const settings: EnforcedWidgetSettings = {
 describe("loadTemplates", () => {
   beforeEach(() => {
     jest.clearAllMocks() // Clear mocks before each test
-  })
-
-  it("should call loadExpandedTileTemplates when loadExpandedTileSlider is true", () => {
-    loadTemplates(settings)
-
-    expect(loadExpandedTileTemplates).toHaveBeenCalled()
-  })
-
-  it("should not call loadExpandedTileTemplates when loadExpandedTileSlider is false", () => {
-    const mutatedSettings = {
-      ...settings,
-      features: {
-        ...settings.features,
-        loadExpandedTileSlider: false
-      }
-    }
-
-    loadTemplates(mutatedSettings)
-
-    expect(loadExpandedTileTemplates).not.toHaveBeenCalled()
   })
 
   it("should not add templates if settings.templates is empty or undefined", () => {

--- a/src/widget-loader.ts
+++ b/src/widget-loader.ts
@@ -12,7 +12,6 @@ import {
   handleAllTileImageRendered,
   renderMasonryLayout
 } from "./libs/extensions/masonry/masonry.extension"
-import { loadExpandedTileTemplates } from "./libs/components/expanded-tile-swiper"
 import { callbackDefaults, loadListeners } from "./events"
 import { EnforcedWidgetSettings, MyWidgetSettings } from "./types/loader"
 import { injectFontFaces } from "./fonts"
@@ -59,7 +58,6 @@ function mergeSettingsWithDefaults(settings?: MyWidgetSettings): EnforcedWidgetS
       addNewTilesAutomatically: true,
       handleLoadMore: true,
       hideBrokenImages: true,
-      loadExpandedTileSlider: true,
       loadTileContent: true,
       loadTimephrase: true,
       ...settings?.features
@@ -142,7 +140,6 @@ export function initialiseFeatures(settings: MyWidgetSettings) {
       addNewTilesAutomatically: true,
       handleLoadMore: true,
       hideBrokenImages: true,
-      loadExpandedTileSlider: true,
       loadTileContent: true,
       loadTimephrase: true
     }
@@ -152,10 +149,6 @@ export function initialiseFeatures(settings: MyWidgetSettings) {
 }
 
 export function loadTemplates(settings: EnforcedWidgetSettings) {
-  if (settings.features.loadExpandedTileSlider) {
-    loadExpandedTileTemplates(settings.templates["expanded-tiles"]?.template ? false : true)
-  }
-
   if (settings.templates && Object.keys(settings.templates).length) {
     Object.entries(settings.templates).forEach(([key, customTemplate]) => {
       if (!customTemplate) {


### PR DESCRIPTION
## Description

Move expanded tile slider template reference to ugc-widgets

## Checklist
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

 