### PR TITLE
feat: :sparkles: Add support for loadTagFallbackUsernameHelper

### DIFF
--- a/.changeset/spotty-meals-relate.md
+++ b/.changeset/spotty-meals-relate.md
@@ -1,0 +1,5 @@
+---
+"@stackla/widget-utils": minor
+---
+
+Add tag fallback username to fallback to tags with @ included if needed

--- a/src/handlebars/helpers/tag-fallback-username.spec.ts
+++ b/src/handlebars/helpers/tag-fallback-username.spec.ts
@@ -1,0 +1,62 @@
+import Handlebars from "handlebars"
+import { loadTagFallbackUsernameHelper } from "./tag-fallback-username"
+
+describe("tagFallbackUsername helper", () => {
+  beforeAll(() => {
+    loadTagFallbackUsernameHelper(Handlebars)
+  })
+
+  const compile = (context: unknown, fallback = "fallback") => {
+    const template = Handlebars.compile(
+      `{{tagFallbackUsername tags_extended=tile.tags_extended user=tile.user terms=tile.terms fallback='${fallback}'}}`
+    )
+    return template({ tile: context })
+  }
+
+  it("returns public content tag with @ if present", () => {
+    const tile = {
+      tags_extended: [
+        { type: "content", publicly_visible: 1, tag: "@public_handle" },
+        { type: "content", publicly_visible: 1, tag: "not_a_handle" }
+      ],
+      user: "user1",
+      terms: ["term1"]
+    }
+    expect(compile(tile)).toContain("@public_handle")
+  })
+
+  it("returns user handle if no matching tag", () => {
+    const tile = {
+      tags_extended: [{ type: "content", publicly_visible: 1, tag: "not_a_handle" }],
+      user: "user2",
+      terms: ["term2"]
+    }
+    expect(compile(tile)).toContain("@user2")
+  })
+
+  it("returns first term if no tag and no user", () => {
+    const tile = {
+      tags_extended: [],
+      terms: ["term3"]
+    }
+    expect(compile(tile)).toContain("@term3")
+  })
+
+  it("returns fallback if no tag, no user, no terms", () => {
+    const tile = {
+      tags_extended: []
+    }
+    expect(compile(tile, "oneractive")).toContain("@oneractive")
+  })
+
+  it("returns first matching tag if multiple present", () => {
+    const tile = {
+      tags_extended: [
+        { type: "content", publicly_visible: 1, tag: "@first" },
+        { type: "content", publicly_visible: 1, tag: "@second" }
+      ],
+      user: "user3"
+    }
+    expect(compile(tile)).toContain("@first")
+  })
+})

--- a/src/handlebars/helpers/tag-fallback-username.ts
+++ b/src/handlebars/helpers/tag-fallback-username.ts
@@ -1,0 +1,18 @@
+import Handlebars from "handlebars"
+import { TagExtended } from "../../types"
+
+export const loadTagFallbackUsernameHelper = (hbs: typeof Handlebars) => {
+  hbs.registerHelper("tagFallbackUsername", function (options) {
+    const { fallback, tags_extended, user, terms } = options?.hash || {}
+
+    const contentTags = tags_extended?.filter(
+      (tag: TagExtended) => tag.type === "content" && tag.publicly_visible && tag.tag.includes("@")
+    )
+
+    const displayedItem = user && user.length ? user : terms && terms.length ? terms[0] : ""
+
+    const content = contentTags?.length ? contentTags[0].tag : `@${displayedItem.length ? displayedItem : fallback}`
+
+    return new hbs.SafeString(`<div class="user-handle">${content}</div>`)
+  })
+}

--- a/src/handlebars/index.ts
+++ b/src/handlebars/index.ts
@@ -9,6 +9,7 @@ import { loadIfShortVideoHelper } from "./helpers/if-short-video.helper"
 import { loadIfHasProductTags } from "./helpers/if-has-product-tags.helper"
 import { loadIfHasPublicTags } from "./helpers/if-has-public-tags.helper"
 import { loadIconsHelper } from "./helpers/load-icons.helper"
+import { loadTagFallbackUsernameHelper } from "./helpers/tag-fallback-username"
 
 export interface HandlebarsPartial {
   name: string
@@ -85,4 +86,5 @@ export function loadHelpers(hbs: typeof Handlebars, widgetId: string) {
   loadIfHasProductTags(hbs)
   loadIfHasPublicTags(hbs)
   loadIconsHelper(hbs, widgetId)
+  loadTagFallbackUsernameHelper(hbs)
 }


### PR DESCRIPTION
This feature will allow users to fallback on tags with @ included

No breaking changes.

## Description

## Checklist
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

 