### PR TITLE
fix: Remove autoplay when it is not in used

### DIFF
--- a/.changeset/funny-lamps-march.md
+++ b/.changeset/funny-lamps-march.md
@@ -1,0 +1,5 @@
+---
+"@stackla/widget-utils": patch
+---
+
+Remove swiper autoplay when it is not needed

--- a/src/libs/components/expanded-tile-swiper/embed-youtube.template.tsx
+++ b/src/libs/components/expanded-tile-swiper/embed-youtube.template.tsx
@@ -60,9 +60,9 @@ export function loadYoutubePlayerAPI(playerId: string, videoId: string, swiperId
   const instance = swiper?.instance;
 
   function onPlayerStateChange(event) {
-    instance?.autoplay.stop();
+    instance?.autoplay?.stop();
     if (event.data === YT.PlayerState.ENDED) {
-      instance?.autoplay.start();
+      instance?.autoplay?.start();
       instance?.slideNext();
     }
   }
@@ -115,7 +115,7 @@ export function loadYoutubePlayerAPI(playerId: string, videoId: string, swiperId
           play();
         } else {
           pause();
-          instance?.autoplay.start();
+          instance?.autoplay?.start();
         }
       });
     }, { threshold: 0.5 });

--- a/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
+++ b/src/libs/components/expanded-tile-swiper/expanded-swiper.loader.ts
@@ -173,7 +173,7 @@ function initalizeStoryExpandedTile(sdk: ISdk, settings: ExpandedTileSettings) {
         navigationNext: (swiper: Swiper) => swiperNavigationHandler(sdk, swiper),
         navigationPrev: (swiper: Swiper) => swiperNavigationHandler(sdk, swiper),
         slideChange: (swiper: Swiper) => {
-          swiper.autoplay.start()
+          swiper?.autoplay?.start()
         }
       },
       ...swiperSettings
@@ -222,13 +222,13 @@ function registerStoryControls(sdk: ISdk, tileWrapper: Element, swiper: Swiper) 
   playCtrl?.addEventListener("click", () => {
     playCtrl.classList.add("hidden")
     pauseCtrl?.classList.remove("hidden")
-    swiper.autoplay.start()
+    swiper?.autoplay?.start()
   })
 
   pauseCtrl?.addEventListener("click", () => {
     pauseCtrl.classList.add("hidden")
     playCtrl?.classList.remove("hidden")
-    swiper.autoplay.stop()
+    swiper?.autoplay?.stop()
   })
 
   volumeCtrl?.addEventListener("click", () => {
@@ -300,8 +300,8 @@ function handleAutoplayProgress(tileWrapper: Element, swiper: Swiper, playCtrl: 
 
   swiperWrapperEle?.addEventListener("mouseleave", () => {
     if (playCtrl?.classList.contains("hidden")) {
-      if (swiper.autoplay.paused) {
-        swiper.autoplay.resume()
+      if (swiper?.autoplay?.paused) {
+        swiper?.autoplay?.resume()
       }
     }
   })

--- a/src/libs/components/expanded-tile-swiper/expanded-tile-video.tsx
+++ b/src/libs/components/expanded-tile-swiper/expanded-tile-video.tsx
@@ -54,6 +54,10 @@ export async function controlVideoPlayback(sdk: ISdk, swiper: Swiper) {
   if (previousElement) {
     triggerPause(previousElement)
   }
+
+  if (!activeElement && !previousElement) {
+    console.warn("No active or previous video element found in controlVideoPlayback")
+  }
 }
 
 /**
@@ -188,6 +192,8 @@ export function getSwiperVideoElement(
   if (videoElement) {
     return { element: videoElement, source: "video" }
   }
+
+  console.warn("Undefined video element", element, tileId)
 
   return undefined
 }

--- a/src/libs/components/expanded-tile-swiper/video.templates.tsx
+++ b/src/libs/components/expanded-tile-swiper/video.templates.tsx
@@ -25,7 +25,7 @@ function getVideoData(tile: Tile) {
 export function handlePauseAutoplay(swiperId: string) {
   const swiperInstance = window.ugc.swiperContainer[swiperId].instance
   if (swiperInstance) {
-    swiperInstance.autoplay.stop()
+    swiperInstance?.autoplay?.stop()
   } else {
     console.error(`Swiper instance for id ${swiperId} not found`)
   }
@@ -34,7 +34,7 @@ export function handlePauseAutoplay(swiperId: string) {
 export function handlePlayAutoplay(swiperId: string) {
   const swiperInstance = window.ugc.swiperContainer[swiperId].instance
   if (swiperInstance) {
-    swiperInstance.autoplay.start()
+    swiperInstance?.autoplay?.start()
   } else {
     console.error(`Swiper instance for id ${swiperId} not found`)
   }

--- a/src/libs/extensions/swiper/swiper.extension.ts
+++ b/src/libs/extensions/swiper/swiper.extension.ts
@@ -99,8 +99,8 @@ export function initializeSwiper(sdk: ISdk, swiperProps: SwiperProps) {
     window.ugc.swiperContainer[mutatedId] = { pageIndex: 1 }
   }
 
-  window.ugc.swiperContainer[mutatedId]!.instance = new window.ugc.libs.Swiper(widgetSelector, {
-    modules: [Navigation, Manipulation, Keyboard, Mousewheel, Autoplay, EffectCoverflow, Pagination, FreeMode],
+  const settings = new window.ugc.libs.Swiper(widgetSelector, {
+    modules: [Navigation, Manipulation, Keyboard, Mousewheel, EffectCoverflow, Pagination, FreeMode],
     spaceBetween: 10,
     observer: true,
     grabCursor: true,
@@ -121,6 +121,12 @@ export function initializeSwiper(sdk: ISdk, swiperProps: SwiperProps) {
     resizeObserver: true,
     ...paramsOverrides
   })
+
+  if (settings.autoplay) {
+    settings.modules.push(Autoplay)
+  }
+
+  window.ugc.swiperContainer[mutatedId]!.instance = settings
 
   if (!sdk.getCustomTemplate("expanded-tiles")) {
     addTilesUpdatedListener(sdk, id, getSliderTemplate)


### PR DESCRIPTION
## Description

When autoplay is not in use, it should be disabled.
At the moment the autoplay automatically turns on which means the slider keeps sliding even though it is not expected to in certain widgets.

## Checklist
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

 