### PR TITLE
fix: sunset masonry extension in widget utils

### DIFF
--- a/.changeset/quiet-peas-clap.md
+++ b/.changeset/quiet-peas-clap.md
@@ -1,0 +1,5 @@
+---
+"@stackla/widget-utils": major
+---
+
+Sunset masonry in widget utils

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -64,25 +64,11 @@ export interface Features {
   cssVariables?: Record<string, string>
 }
 
-interface Extensions {
-  /**
-   * Load the Swiper extension for inline tiles
-   * @default false
-   * */
-  swiper: boolean
-  /**
-   * Load the Masonry extension for inline tiles
-   * @default false
-   * */
-  masonry: boolean
-}
-
 type Templates = Record<string, Template>
 
 export interface MyWidgetSettings {
   features?: Partial<Features>
   callbacks?: Partial<Callbacks>
-  extensions?: Partial<Extensions>
   templates?: Partial<Templates>
   config?: Partial<WidgetConfig>
 }
@@ -90,5 +76,4 @@ export interface MyWidgetSettings {
 export interface EnforcedWidgetSettings extends Required<MyWidgetSettings> {
   features: Features
   callbacks: Callbacks
-  extensions: Extensions
 }

--- a/src/widget-loader.spec.tsx
+++ b/src/widget-loader.spec.tsx
@@ -28,10 +28,6 @@ const settings: EnforcedWidgetSettings = {
   callbacks: {
     ...callbackDefaults
   },
-  extensions: {
-    swiper: false,
-    masonry: false
-  },
   templates: {
     direct_uploader: () => "<p>Hello!</p>",
     shopspots: () => "<p>Hi!</p>"

--- a/src/widget-loader.ts
+++ b/src/widget-loader.ts
@@ -2,51 +2,9 @@ import { addAutoAddTileFeature, loadExpandedTileFeature, loadTitle } from "./lib
 import { addCSSVariablesToPlacement } from "./libs/widget.layout"
 import getCSSVariables from "./libs/css-variables"
 import { ISdk } from "./types"
-import {
-  handleTileImageError,
-  handleAllTileImageRendered,
-  renderMasonryLayout
-} from "./libs/extensions/masonry/masonry.extension"
 import { callbackDefaults, loadListeners } from "./events"
 import { EnforcedWidgetSettings, MyWidgetSettings } from "./types/loader"
 import { injectFontFaces } from "./fonts"
-
-function loadMasonryCallbacks(sdk: ISdk, settings: EnforcedWidgetSettings) {
-  const tilesUpdatedObserver = new MutationObserver(() => {
-    renderMasonryLayout(sdk)
-  })
-
-  tilesUpdatedObserver.observe(sdk.querySelector(".ugc-tiles")!, {
-    childList: true,
-    subtree: true
-  })
-
-  settings.callbacks.onTileBgImgRenderComplete.push(() => {
-    handleAllTileImageRendered(sdk)
-    setTimeout(() => handleAllTileImageRendered(sdk), 1000)
-  })
-
-  settings.callbacks.onTileBgImageError.push(event => {
-    const customEvent = event
-    const tileWithError = customEvent.detail.data.target as HTMLElement
-    handleTileImageError(sdk, tileWithError)
-  })
-
-  const grid = sdk.querySelector(".grid")
-
-  if (!grid) {
-    console.error("Grid element not found")
-    return settings
-  }
-
-  const observer = new ResizeObserver(() => {
-    renderMasonryLayout(sdk)
-  })
-
-  observer.observe(grid)
-
-  return settings
-}
 
 function mergeSettingsWithDefaults(settings?: MyWidgetSettings): EnforcedWidgetSettings {
   return {
@@ -64,11 +22,6 @@ function mergeSettingsWithDefaults(settings?: MyWidgetSettings): EnforcedWidgetS
     callbacks: {
       ...callbackDefaults,
       ...settings?.callbacks
-    },
-    extensions: {
-      swiper: false,
-      masonry: false,
-      ...settings?.extensions
     },
     templates: settings?.templates ?? {},
     config: settings?.config ?? {}
@@ -113,17 +66,6 @@ async function loadFeatures(sdk: ISdk, settings: EnforcedWidgetSettings) {
 
   if (handleLoadMore) {
     sdk.addLoadedComponents(["load-more"])
-  }
-
-  return settings
-}
-
-function loadExtensions(sdk: ISdk, settings: EnforcedWidgetSettings) {
-  const { extensions } = settings
-
-  if (extensions?.masonry) {
-    settings = loadMasonryCallbacks(sdk, settings)
-    renderMasonryLayout(sdk)
   }
 
   return settings
@@ -202,7 +144,6 @@ export function loadWidget(sdk: ISdk, settings?: MyWidgetSettings) {
   addConfigFilter(sdk, settingsWithDefaults)
   loadTemplates(sdk, settingsWithDefaults)
   loadFeatures(sdk, settingsWithDefaults)
-  loadExtensions(sdk, settingsWithDefaults)
   loadListeners(sdk, settingsWithDefaults)
   injectFontFaces(document.head, settings?.config?.fonts)
   injectFontFaces(sdk.getShadowRoot(), settings?.config?.fonts)


### PR DESCRIPTION
## Description

Sunset masonry extension, along with extensions type. 
We do not need this anymore, as it has been added to masonry widget template (and thats the only template using it)

## Checklist
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

 