### PR TITLE
feat: add support for ref in createElement to enable usage in JSX

### DIFF
--- a/.changeset/shaggy-insects-end.md
+++ b/.changeset/shaggy-insects-end.md
@@ -1,0 +1,5 @@
+---
+"@stackla/widget-utils": minor
+---
+
+Add support for ref, to allow usage in JSX

--- a/src/libs/jsx-html.spec.tsx
+++ b/src/libs/jsx-html.spec.tsx
@@ -106,3 +106,27 @@ describe("JSX mapping", () => {
     expect(element2.outerHTML).toEqual("<div></div>")
   })
 })
+
+describe("createElement ref support", () => {
+  it("calls ref function with the created element", () => {
+    let refElement: HTMLElement | null = null
+    const refFn = (el: HTMLElement) => {
+      refElement = el
+    }
+    const el = createElement("div", { ref: refFn })
+    expect(refElement).toBe(el)
+    expect(el.tagName).toBe("DIV")
+  })
+
+  it("assigns element to ref object", () => {
+    const refObj = { current: null as HTMLElement | null }
+    const el = createElement("span", { ref: refObj })
+    expect(refObj.current).toBe(el)
+    expect(el.tagName).toBe("SPAN")
+  })
+
+  it("does not fail if ref is not provided", () => {
+    const el = createElement("section", {})
+    expect(el.tagName).toBe("SECTION")
+  })
+})


### PR DESCRIPTION
## Description
Add support for ref, similar to react useRef.
Allows you to persist a value across renders without causing re-renders when it changes.

For instance, i will useRef to attach an intersection observer to that given div.

## Checklist
- [ ] Pull Request is properly described.
- [ ] The corresponding Jira ticket is updated.
- [ ] I have requested a review from at least one reviewer.
- [ ] The changes are tested
- [ ] I have verified my UX changes with a designer
- [ ] I have checked my code for any possible security vulnerabilities

 