### PR TITLE
chore: UGCPH-521: add ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION to workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ permissions:
   id-token: write
 
 env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
   GH_TOKEN: ${{ github.token }}
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
         default: staging
 
 env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
   NODE_AUTH_TOKEN: ${{ secrets.STACKLA_BOT_GITHUB_TOKEN }}
 
 jobs:

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch:
 
 env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
   NODE_AUTH_TOKEN: ${{secrets.STACKLA_BOT_GITHUB_TOKEN}}
 
 permissions:

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -12,6 +12,9 @@ permissions:
     contents: write
     pull-requests: read
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
     stale_branches:
         runs-on: ubuntu-latest

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -13,7 +13,7 @@ permissions:
     pull-requests: read
 
 env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
     stale_branches:


### PR DESCRIPTION
# Description of change

Add `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` environment variable to all GitHub Actions workflow files.

This temporarily opts out of the Node.js 24 default behavior to restore Node.js 20 compatibility while we plan and execute the full upgrade path to Node.js 24.

Actions will default to Node.js 24 starting June 2nd, 2026, and Node.js 20 will be removed by September 16th, 2026.

Ticket: UGCPH-521

# How have you tested your code?

Configuration-only change. No application code was modified.

# Dependencies

None.